### PR TITLE
Add admin fees and owner statements feature

### DIFF
--- a/api/app/controllers/v1/bank_statements_controller.rb
+++ b/api/app/controllers/v1/bank_statements_controller.rb
@@ -1,0 +1,17 @@
+module V1
+  class BankStatementsController < ApplicationController
+    def show
+      statement = BankStatement.find(params[:id])
+      authorize statement, :show?
+      render json: { data: BankStatementSerializer.new(statement) }
+    end
+
+    def import
+      authorize BankStatement, :create?
+      file = params.require(:file)
+      # Minimal stub: create a BankStatement record capturing filename
+      statement = BankStatement.create!(account: 'default', statement_on: Date.today, original_filename: file.respond_to?(:original_filename) ? file.original_filename : 'upload')
+      render json: { data: BankStatementSerializer.new(statement) }, status: :created
+    end
+  end
+end

--- a/api/app/controllers/v1/bank_statements_controller.rb
+++ b/api/app/controllers/v1/bank_statements_controller.rb
@@ -10,8 +10,14 @@ module V1
       authorize BankStatement, :create?
       file = params.require(:file)
       # Minimal stub: create a BankStatement record capturing filename
-      statement = BankStatement.create!(account: 'default', statement_on: Date.today, original_filename: file.respond_to?(:original_filename) ? file.original_filename : 'upload')
-      render json: { data: BankStatementSerializer.new(statement) }, status: :created
+      statement = BankStatement.new(account: 'default', statement_on: Date.today,
+                                    original_filename: file.respond_to?(:original_filename) ? file.original_filename : 'upload')
+      statement.imported_by_user = current_user
+      if statement.save
+        render json: { data: BankStatementSerializer.new(statement) }, status: :created
+      else
+        render_errors(statement.errors.full_messages)
+      end
     end
   end
 end

--- a/api/app/controllers/v1/fees_controller.rb
+++ b/api/app/controllers/v1/fees_controller.rb
@@ -1,0 +1,10 @@
+module V1
+  class FeesController < ApplicationController
+    def calculate
+      authorize Contract, :index?
+      period = params.require(:period)
+      generated = Fees::Calculator.new(period: period).call
+      render json: { generated: generated }
+    end
+  end
+end

--- a/api/app/controllers/v1/invoices_controller.rb
+++ b/api/app/controllers/v1/invoices_controller.rb
@@ -1,0 +1,24 @@
+module V1
+  class InvoicesController < ApplicationController
+    include Pagy::Backend
+
+    def index
+      authorize Invoice, :index?
+      scope = Invoice.order(issue_on: :desc)
+      pagy_obj, records = pagy(scope)
+      render json: { data: ActiveModelSerializers::SerializableResource.new(records, each_serializer: InvoiceSerializer), pagy: pagy_metadata(pagy_obj) }
+    end
+
+    def show
+      invoice = Invoice.find(params[:id])
+      authorize invoice, :show?
+      render json: { data: InvoiceSerializer.new(invoice) }
+    end
+
+    private
+
+    def pagy_metadata(pagy)
+      { page: pagy.page, items: pagy.items, pages: pagy.pages, count: pagy.count }
+    end
+  end
+end

--- a/api/app/controllers/v1/invoices_controller.rb
+++ b/api/app/controllers/v1/invoices_controller.rb
@@ -6,7 +6,7 @@ module V1
       authorize Invoice, :index?
       scope = Invoice.order(issue_on: :desc)
       pagy_obj, records = pagy(scope)
-      render json: { data: ActiveModelSerializers::SerializableResource.new(records, each_serializer: InvoiceSerializer), pagy: pagy_metadata(pagy_obj) }
+      render_collection(records, serializer: InvoiceSerializer, pagy: pagy_obj)
     end
 
     def show
@@ -16,9 +16,6 @@ module V1
     end
 
     private
-
-    def pagy_metadata(pagy)
-      { page: pagy.page, items: pagy.items, pages: pagy.pages, count: pagy.count }
-    end
+    # metadata is provided by Renderable#render_collection
   end
 end

--- a/api/app/controllers/v1/owner_statements_controller.rb
+++ b/api/app/controllers/v1/owner_statements_controller.rb
@@ -1,0 +1,18 @@
+module V1
+  class OwnerStatementsController < ApplicationController
+    def index
+      authorize Property, :index?
+      period = params.require(:period)
+      Statements::Builder.new(period: period).call
+      scope = OwnerStatement.where(period: period)
+      scope = scope.where(property_id: params[:property_id]) if params[:property_id]
+      render json: { data: ActiveModelSerializers::SerializableResource.new(scope, each_serializer: OwnerStatementSerializer) }
+    end
+
+    def show
+      authorize Property, :show?
+      st = OwnerStatement.find(params[:id])
+      render json: { data: OwnerStatementSerializer.new(st) }
+    end
+  end
+end

--- a/api/app/controllers/v1/payments_controller.rb
+++ b/api/app/controllers/v1/payments_controller.rb
@@ -6,7 +6,7 @@ module V1
       authorize Payment, :index?
       scope = Payment.order(received_on: :desc)
       pagy_obj, records = pagy(scope)
-      render json: { data: ActiveModelSerializers::SerializableResource.new(records, each_serializer: PaymentSerializer), pagy: pagy_metadata(pagy_obj) }
+      render_collection(records, serializer: PaymentSerializer, pagy: pagy_obj)
     end
 
     def create
@@ -15,7 +15,7 @@ module V1
       if payment.save
         render json: { data: PaymentSerializer.new(payment) }, status: :created
       else
-        render json: { errors: payment.errors.full_messages }, status: :unprocessable_entity
+        render_errors(payment.errors.full_messages)
       end
     end
 
@@ -31,7 +31,7 @@ module V1
       if payment.update(payment_params)
         render json: { data: PaymentSerializer.new(payment) }
       else
-        render json: { errors: payment.errors.full_messages }, status: :unprocessable_entity
+        render_errors(payment.errors.full_messages)
       end
     end
 
@@ -41,8 +41,6 @@ module V1
       params.require(:payment).permit(:tenant_id, :received_on, :amount_cents, :currency, :payment_method, :reference, :status)
     end
 
-    def pagy_metadata(pagy)
-      { page: pagy.page, items: pagy.items, pages: pagy.pages, count: pagy.count }
-    end
+    # metadata is provided by Renderable#render_collection
   end
 end

--- a/api/app/controllers/v1/payments_controller.rb
+++ b/api/app/controllers/v1/payments_controller.rb
@@ -1,0 +1,48 @@
+module V1
+  class PaymentsController < ApplicationController
+    include Pagy::Backend
+
+    def index
+      authorize Payment, :index?
+      scope = Payment.order(received_on: :desc)
+      pagy_obj, records = pagy(scope)
+      render json: { data: ActiveModelSerializers::SerializableResource.new(records, each_serializer: PaymentSerializer), pagy: pagy_metadata(pagy_obj) }
+    end
+
+    def create
+      payment = Payment.new(payment_params)
+      authorize payment, :create?
+      if payment.save
+        render json: { data: PaymentSerializer.new(payment) }, status: :created
+      else
+        render json: { errors: payment.errors.full_messages }, status: :unprocessable_entity
+      end
+    end
+
+    def show
+      payment = Payment.find(params[:id])
+      authorize payment, :show?
+      render json: { data: PaymentSerializer.new(payment) }
+    end
+
+    def update
+      payment = Payment.find(params[:id])
+      authorize payment, :update?
+      if payment.update(payment_params)
+        render json: { data: PaymentSerializer.new(payment) }
+      else
+        render json: { errors: payment.errors.full_messages }, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def payment_params
+      params.require(:payment).permit(:tenant_id, :received_on, :amount_cents, :currency, :payment_method, :reference, :status)
+    end
+
+    def pagy_metadata(pagy)
+      { page: pagy.page, items: pagy.items, pages: pagy.pages, count: pagy.count }
+    end
+  end
+end

--- a/api/app/controllers/v1/statement_lines_controller.rb
+++ b/api/app/controllers/v1/statement_lines_controller.rb
@@ -1,0 +1,18 @@
+module V1
+  class StatementLinesController < ApplicationController
+    def match
+      line = StatementLine.find(params[:id])
+      authorize line, :update?
+      payment_id = params.require(:payment_id)
+      line.update!(match_status: 'matched', matched_payment_id: payment_id)
+      render json: { data: StatementLineSerializer.new(line) }
+    end
+
+    def ignore
+      line = StatementLine.find(params[:id])
+      authorize line, :update?
+      line.update!(match_status: 'ignored')
+      render json: { data: StatementLineSerializer.new(line) }
+    end
+  end
+end

--- a/api/app/models/admin_fee.rb
+++ b/api/app/models/admin_fee.rb
@@ -1,0 +1,6 @@
+class AdminFee < ApplicationRecord
+  belongs_to :contract
+  enum :status, { calculated: "calculated", invoiced: "invoiced" }, prefix: true
+
+  validates :period, :base_cents, :fee_rate_pct, :fee_cents, presence: true
+end

--- a/api/app/models/owner_statement.rb
+++ b/api/app/models/owner_statement.rb
@@ -1,0 +1,6 @@
+class OwnerStatement < ApplicationRecord
+  belongs_to :property
+
+  validates :period, presence: true
+  validates :total_rent_cents, :total_expenses_cents, :total_fees_cents, :net_cents, numericality: { greater_than_or_equal_to: 0 }
+end

--- a/api/app/policies/bank_statement_policy.rb
+++ b/api/app/policies/bank_statement_policy.rb
@@ -1,0 +1,9 @@
+class BankStatementPolicy < ApplicationPolicy
+  def show?
+    user.present?
+  end
+
+  def create?
+    user.present?
+  end
+end

--- a/api/app/policies/payment_policy.rb
+++ b/api/app/policies/payment_policy.rb
@@ -1,0 +1,17 @@
+class PaymentPolicy < ApplicationPolicy
+  def index?
+    user.present?
+  end
+
+  def show?
+    user.present?
+  end
+
+  def create?
+    user.present?
+  end
+
+  def update?
+    user.present?
+  end
+end

--- a/api/app/policies/statement_line_policy.rb
+++ b/api/app/policies/statement_line_policy.rb
@@ -1,0 +1,5 @@
+class StatementLinePolicy < ApplicationPolicy
+  def update?
+    user.present?
+  end
+end

--- a/api/app/serializers/admin_fee_serializer.rb
+++ b/api/app/serializers/admin_fee_serializer.rb
@@ -1,0 +1,3 @@
+class AdminFeeSerializer < ActiveModel::Serializer
+  attributes :id, :contract_id, :period, :base_cents, :fee_rate_pct, :fee_cents, :status, :created_at
+end

--- a/api/app/serializers/owner_statement_serializer.rb
+++ b/api/app/serializers/owner_statement_serializer.rb
@@ -1,0 +1,3 @@
+class OwnerStatementSerializer < ActiveModel::Serializer
+  attributes :id, :property_id, :period, :total_rent_cents, :total_expenses_cents, :total_fees_cents, :net_cents, :created_at
+end

--- a/api/app/services/fees/calculator.rb
+++ b/api/app/services/fees/calculator.rb
@@ -1,0 +1,36 @@
+module Fees
+  class Calculator
+    # Calculates admin fees for a given period (YYYY-MM)
+    def initialize(period:)
+      @period = period
+      @month_start = Date.strptime("#{period}-01", "%Y-%m-%d").beginning_of_month
+      @month_end = @month_start.end_of_month
+    end
+
+    def call
+      generated = 0
+      Contract.active.find_each do |contract|
+        base_cents = monthly_collected_cents(contract)
+        next if base_cents <= 0
+        rate = contract.fee_rate_pct.to_d
+        fee_cents = ((base_cents.to_d * rate) / 100).to_i
+        AdminFee.find_or_create_by!(contract_id: contract.id, period: @period) do |fee|
+          fee.base_cents = base_cents
+          fee.fee_rate_pct = rate
+          fee.fee_cents = fee_cents
+        end
+        generated += 1
+      end
+      generated
+    end
+
+    private
+
+    def monthly_collected_cents(contract)
+      # sum of allocations applied to invoices of this contract in the period
+      Invoice.where(contract_id: contract.id, issue_on: @month_start..@month_end)
+             .joins(:payment_allocations)
+             .sum(:amount_cents)
+    end
+  end
+end

--- a/api/app/services/fees/calculator.rb
+++ b/api/app/services/fees/calculator.rb
@@ -27,10 +27,10 @@ module Fees
     private
 
     def monthly_collected_cents(contract)
-      # sum of allocations applied to invoices of this contract in the period
-      Invoice.where(contract_id: contract.id, issue_on: @month_start..@month_end)
-             .joins(:payment_allocations)
-             .sum(:amount_cents)
+      # Sum of allocation amounts applied to invoices of this contract in the period
+      PaymentAllocation.joins(:invoice)
+                       .where(invoices: { contract_id: contract.id, issue_on: @month_start..@month_end })
+                       .sum(:amount_cents)
     end
   end
 end

--- a/api/app/services/statements/builder.rb
+++ b/api/app/services/statements/builder.rb
@@ -25,10 +25,9 @@ module Statements
     private
 
     def rent_collected_cents(property)
-      Invoice.joins(:contract)
-             .where(contracts: { property_id: property.id }, issue_on: @month_start..@month_end)
-             .joins(:payment_allocations)
-             .sum(:amount_cents)
+      PaymentAllocation.joins(invoice: :contract)
+                       .where(contracts: { property_id: property.id }, invoices: { issue_on: @month_start..@month_end })
+                       .sum(:amount_cents)
     end
 
     def expenses_cents(property)

--- a/api/app/services/statements/builder.rb
+++ b/api/app/services/statements/builder.rb
@@ -1,0 +1,45 @@
+module Statements
+  class Builder
+    # Builds or updates owner statements per property for period (YYYY-MM)
+    def initialize(period:)
+      @period = period
+      @month_start = Date.strptime("#{period}-01", "%Y-%m-%d").beginning_of_month
+      @month_end = @month_start.end_of_month
+    end
+
+    def call
+      Property.find_each do |property|
+        total_rent = rent_collected_cents(property)
+        total_expenses = expenses_cents(property)
+        total_fees = fees_cents(property)
+        net = total_rent - total_expenses - total_fees
+        OwnerStatement.find_or_create_by!(property_id: property.id, period: @period) do |st|
+          st.total_rent_cents = total_rent
+          st.total_expenses_cents = total_expenses
+          st.total_fees_cents = total_fees
+          st.net_cents = net
+        end
+      end
+    end
+
+    private
+
+    def rent_collected_cents(property)
+      Invoice.joins(:contract)
+             .where(contracts: { property_id: property.id }, issue_on: @month_start..@month_end)
+             .joins(:payment_allocations)
+             .sum(:amount_cents)
+    end
+
+    def expenses_cents(property)
+      # Placeholder: sum of suppliers expenses for property in period when modeled
+      0
+    end
+
+    def fees_cents(property)
+      AdminFee.joins(contract: :property)
+              .where(contracts: { property_id: property.id }, period: @period)
+              .sum(:fee_cents)
+    end
+  end
+end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -38,6 +38,10 @@ Rails.application.routes.draw do
     # Milestone 4: automation & dunning
     post "invoicing/generate_monthly", to: "invoicing#generate_monthly"
     get "dunning/candidates", to: "dunning#candidates"
+
+    # Milestone 5: admin fees & owner statements
+    post "fees/calculate", to: "fees#calculate"
+    resources :owner_statements, only: %i[index show]
   end
 
   # rails health

--- a/api/db/migrate/20250809030000_add_fee_rate_to_contracts.rb
+++ b/api/db/migrate/20250809030000_add_fee_rate_to_contracts.rb
@@ -1,0 +1,6 @@
+class AddFeeRateToContracts < ActiveRecord::Migration[8.0]
+  def change
+    add_column :contracts, :fee_rate_pct, :decimal, precision: 5, scale: 2, null: false, default: 10.0
+    add_index :contracts, :fee_rate_pct
+  end
+end

--- a/api/db/migrate/20250809030100_create_admin_fees.rb
+++ b/api/db/migrate/20250809030100_create_admin_fees.rb
@@ -1,0 +1,16 @@
+class CreateAdminFees < ActiveRecord::Migration[8.0]
+  def change
+    create_table :admin_fees, id: :uuid do |t|
+      t.uuid :contract_id, null: false
+      t.string :period, null: false # YYYY-MM
+      t.integer :base_cents, null: false
+      t.decimal :fee_rate_pct, precision: 5, scale: 2, null: false
+      t.integer :fee_cents, null: false
+      t.string :status, null: false, default: 'calculated'
+      t.timestamps
+    end
+
+    add_foreign_key :admin_fees, :contracts
+    add_index :admin_fees, [ :contract_id, :period ], unique: true
+  end
+end

--- a/api/db/migrate/20250809030200_create_owner_statements.rb
+++ b/api/db/migrate/20250809030200_create_owner_statements.rb
@@ -1,0 +1,16 @@
+class CreateOwnerStatements < ActiveRecord::Migration[8.0]
+  def change
+    create_table :owner_statements, id: :uuid do |t|
+      t.uuid :property_id, null: false
+      t.string :period, null: false # YYYY-MM
+      t.integer :total_rent_cents, null: false, default: 0
+      t.integer :total_expenses_cents, null: false, default: 0
+      t.integer :total_fees_cents, null: false, default: 0
+      t.integer :net_cents, null: false, default: 0
+      t.timestamps
+    end
+
+    add_foreign_key :owner_statements, :properties
+    add_index :owner_statements, [ :property_id, :period ], unique: true
+  end
+end

--- a/api/spec/factories/admin_fees.rb
+++ b/api/spec/factories/admin_fees.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :admin_fee do
+    contract
+    period { '2025-08' }
+    base_cents { 100_00 }
+    fee_rate_pct { 10.0 }
+    fee_cents { 10_00 }
+    status { 'calculated' }
+  end
+end

--- a/api/spec/factories/owner_statements.rb
+++ b/api/spec/factories/owner_statements.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :owner_statement do
+    property
+    period { '2025-08' }
+    total_rent_cents { 0 }
+    total_expenses_cents { 0 }
+    total_fees_cents { 0 }
+    net_cents { 0 }
+  end
+end

--- a/api/spec/requests/v1/bank_statements_spec.rb
+++ b/api/spec/requests/v1/bank_statements_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe 'V1::BankStatements', type: :request do
+  let!(:user) { create(:user, email: 'admin@example.com', password: 'Password123!', password_confirmation: 'Password123!') }
+
+  def auth_headers
+    post '/v1/auth/login', params: { email: user.email, password: 'Password123!' }, as: :json
+    token = JSON.parse(response.body)['token']
+    { 'Authorization' => "Bearer #{token}" }
+  end
+
+  it 'imports a bank statement' do
+    file = Rack::Test::UploadedFile.new(StringIO.new('data'), 'text/plain', original_filename: 'stmt.csv')
+    post '/v1/bank_statements/import', params: { file: file }, headers: auth_headers
+    expect(response).to have_http_status(:created)
+    body = JSON.parse(response.body)
+    expect(body['data']['original_filename']).to eq('stmt.csv')
+  end
+
+  it 'shows a bank statement' do
+    st = create(:bank_statement)
+    get "/v1/bank_statements/#{st.id}", headers: auth_headers
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body)
+    expect(body['data']['id']).to eq(st.id)
+  end
+end

--- a/api/spec/requests/v1/fees_spec.rb
+++ b/api/spec/requests/v1/fees_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe 'V1::Fees', type: :request do
+  let!(:user) { create(:user, email: 'admin@example.com', password: 'Password123!', password_confirmation: 'Password123!') }
+
+  def auth_headers
+    post '/v1/auth/login', params: { email: user.email, password: 'Password123!' }, as: :json
+    token = JSON.parse(response.body)['token']
+    { 'Authorization' => "Bearer #{token}" }
+  end
+
+  it 'calculates admin fees for a period' do
+    contract = create(:contract, start_on: '2025-01-01', end_on: '2025-12-31', due_day: 5, monthly_rent: 1000, fee_rate_pct: 10.0)
+    inv = create(:invoice, contract: contract, tenant: contract.tenant, issue_on: Date.new(2025,8,1), due_on: Date.new(2025,8,5), amount_cents: 100_00, balance_cents: 0)
+    pay = create(:payment, amount_cents: 100_00)
+    create(:payment_allocation, payment: pay, invoice: inv, amount_cents: 100_00)
+
+    post '/v1/fees/calculate', params: { period: '2025-08' }, headers: auth_headers
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body)
+    expect(body['generated']).to be >= 1
+  end
+end

--- a/api/spec/requests/v1/invoices_spec.rb
+++ b/api/spec/requests/v1/invoices_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe 'V1::Invoices', type: :request do
+  let!(:user) { create(:user, email: 'admin@example.com', password: 'Password123!', password_confirmation: 'Password123!') }
+
+  def auth_headers
+    post '/v1/auth/login', params: { email: user.email, password: 'Password123!' }, as: :json
+    token = JSON.parse(response.body)['token']
+    { 'Authorization' => "Bearer #{token}" }
+  end
+
+  it 'lists invoices (index)' do
+    create_list(:invoice, 2)
+    get '/v1/invoices', headers: auth_headers
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body)
+    expect(body['data']).to be_an(Array)
+    expect(body['data'].length).to be >= 1
+  end
+
+  it 'shows invoice (show)' do
+    invoice = create(:invoice)
+    get "/v1/invoices/#{invoice.id}", headers: auth_headers
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body)
+    expect(body['data']['id']).to eq(invoice.id)
+  end
+end

--- a/api/spec/requests/v1/owner_statements_spec.rb
+++ b/api/spec/requests/v1/owner_statements_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe 'V1::OwnerStatements', type: :request do
+  let!(:user) { create(:user, email: 'admin@example.com', password: 'Password123!', password_confirmation: 'Password123!') }
+
+  def auth_headers
+    post '/v1/auth/login', params: { email: user.email, password: 'Password123!' }, as: :json
+    token = JSON.parse(response.body)['token']
+    { 'Authorization' => "Bearer #{token}" }
+  end
+
+  it 'lists owner statements for a period (index)' do
+    property = create(:property)
+    contract = create(:contract, property: property, start_on: '2025-01-01', end_on: '2025-12-31', due_day: 5, monthly_rent: 1000, fee_rate_pct: 10.0)
+    inv = create(:invoice, contract: contract, tenant: contract.tenant, issue_on: Date.new(2025, 8, 1), due_on: Date.new(2025, 8, 5), amount_cents: 100_00, balance_cents: 0)
+    pay = create(:payment, amount_cents: 100_00)
+    create(:payment_allocation, payment: pay, invoice: inv, amount_cents: 100_00)
+    create(:admin_fee, contract: contract, period: '2025-08', base_cents: 100_00, fee_rate_pct: 10.0, fee_cents: 10_00)
+
+    get '/v1/owner_statements', params: { period: '2025-08' }, headers: auth_headers
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body)
+    expect(body['data']).to be_an(Array)
+    expect(body['data'].length).to be >= 1
+    expect(body['data'].first['period']).to eq('2025-08')
+  end
+
+  it 'shows a single owner statement (show)' do
+    property = create(:property)
+    st = create(:owner_statement, property: property, period: '2025-08', total_rent_cents: 100_00, total_expenses_cents: 0, total_fees_cents: 10_00, net_cents: 90_00)
+
+    get "/v1/owner_statements/#{st.id}", headers: auth_headers
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body)
+    expect(body['data']['id']).to eq(st.id)
+    expect(body['data']['property_id']).to eq(property.id)
+  end
+end

--- a/api/spec/requests/v1/payments_spec.rb
+++ b/api/spec/requests/v1/payments_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe 'V1::Payments', type: :request do
+  let!(:user) { create(:user, email: 'admin@example.com', password: 'Password123!', password_confirmation: 'Password123!') }
+
+  def auth_headers
+    post '/v1/auth/login', params: { email: user.email, password: 'Password123!' }, as: :json
+    token = JSON.parse(response.body)['token']
+    { 'Authorization' => "Bearer #{token}" }
+  end
+
+  it 'lists payments (index)' do
+    create_list(:payment, 2)
+    get '/v1/payments', headers: auth_headers
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body)
+    expect(body['data']).to be_an(Array)
+    expect(body['data'].length).to be >= 1
+  end
+
+  it 'creates and updates a payment' do
+    tenant = create(:tenant)
+    post '/v1/payments', params: { payment: { tenant_id: tenant.id, received_on: Date.today, amount_cents: 100_00, currency: 'USD', payment_method: 'cash', reference: 'ref-1', status: 'captured' } }, headers: auth_headers
+    expect(response).to have_http_status(:created)
+    body = JSON.parse(response.body)
+    id = body['data']['id']
+
+    patch "/v1/payments/#{id}", params: { payment: { reference: 'ref-2' } }, headers: auth_headers
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body)
+    expect(body['data']['reference']).to eq('ref-2')
+  end
+
+  it 'shows payment (show)' do
+    payment = create(:payment)
+    get "/v1/payments/#{payment.id}", headers: auth_headers
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body)
+    expect(body['data']['id']).to eq(payment.id)
+  end
+end

--- a/api/spec/requests/v1/statement_lines_spec.rb
+++ b/api/spec/requests/v1/statement_lines_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe 'V1::StatementLines', type: :request do
+  let!(:user) { create(:user, email: 'admin@example.com', password: 'Password123!', password_confirmation: 'Password123!') }
+
+  def auth_headers
+    post '/v1/auth/login', params: { email: user.email, password: 'Password123!' }, as: :json
+    token = JSON.parse(response.body)['token']
+    { 'Authorization' => "Bearer #{token}" }
+  end
+
+  it 'matches and ignores a statement line' do
+    line = create(:statement_line)
+    payment = create(:payment)
+
+    post "/v1/statement_lines/#{line.id}/match", params: { payment_id: payment.id }, headers: auth_headers
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body)
+    expect(body['data']['match_status']).to eq('matched')
+
+    post "/v1/statement_lines/#{line.id}/ignore", headers: auth_headers
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body)
+    expect(body['data']['match_status']).to eq('ignored')
+  end
+end

--- a/api/spec/services/fees/calculator_spec.rb
+++ b/api/spec/services/fees/calculator_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Fees::Calculator do
+  it 'creates admin fees per active contract with collected base' do
+    contract = create(:contract, start_on: '2025-01-01', end_on: '2025-12-31', due_day: 5, monthly_rent: 1000, fee_rate_pct: 10.0)
+    # simulate rent collection via allocations
+    inv = create(:invoice, contract: contract, tenant: contract.tenant, issue_on: Date.new(2025, 8, 1), due_on: Date.new(2025, 8, 5), amount_cents: 100_00, balance_cents: 50_00)
+    pay = create(:payment, amount_cents: 100_00)
+    create(:payment_allocation, payment: pay, invoice: inv, amount_cents: 50_00)
+
+    calc = described_class.new(period: '2025-08')
+    expect { calc.call }.to change(AdminFee, :count).by(1)
+    fee = AdminFee.last
+    expect(fee.base_cents).to eq(50_00)
+    expect(fee.fee_cents).to eq(5_00)
+  end
+end

--- a/api/spec/services/statements/builder_spec.rb
+++ b/api/spec/services/statements/builder_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Statements::Builder do
+  it 'builds owner statement with rent and fees' do
+    property = create(:property)
+    contract = create(:contract, property: property, start_on: '2025-01-01', end_on: '2025-12-31', due_day: 5, monthly_rent: 1000, fee_rate_pct: 10.0)
+    inv = create(:invoice, contract: contract, tenant: contract.tenant, issue_on: Date.new(2025, 8, 1), due_on: Date.new(2025, 8, 5), amount_cents: 100_00, balance_cents: 0)
+    pay = create(:payment, amount_cents: 100_00)
+    create(:payment_allocation, payment: pay, invoice: inv, amount_cents: 100_00)
+    create(:admin_fee, contract: contract, period: '2025-08', base_cents: 100_00, fee_rate_pct: 10.0, fee_cents: 10_00)
+
+    builder = described_class.new(period: '2025-08')
+    expect { builder.call }.to change(OwnerStatement, :count).by(1)
+    st = OwnerStatement.last
+    expect(st.total_rent_cents).to eq(100_00)
+    expect(st.total_fees_cents).to eq(10_00)
+    expect(st.net_cents).to eq(90_00)
+  end
+end


### PR DESCRIPTION

This pull request introduces the core functionality for calculating admin fees and generating owner statements for properties, as part of milestone 5. It adds new models, services, API endpoints, and migrations to support monthly fee calculation and statement building, along with tests and serializers for these features.

**Admin Fees and Owner Statements Functionality**

* Added `AdminFee` and `OwnerStatement` models with necessary fields, validations, and associations. [[1]](diffhunk://#diff-921b03e2c8b4985b9949ca9632eb03981c3c887b4fcd324bb574962bdcdff7a6R1-R6) [[2]](diffhunk://#diff-337310450bbecf8cc5f927341e0bfce0d969e05c483fb865698aa3b15344d193R1-R6)
* Created services: `Fees::Calculator` for calculating admin fees per contract, and `Statements::Builder` for generating owner statements per property and period. [[1]](diffhunk://#diff-b234ca56c3ca16a8017f378fda6b28c870a2fc8dbcf1066101e1215108965bbaR1-R36) [[2]](diffhunk://#diff-2fd051b99a7263bd65a2f47ebf07cff463165c95b51924afc83bc36c6a5ad240R1-R45)
* Introduced API endpoints: `POST /v1/fees/calculate` for fee calculation and `GET /v1/owner_statements`/`GET /v1/owner_statements/:id` for statement retrieval, with corresponding controllers. [[1]](diffhunk://#diff-cc94671af5478a02d687d17ba0dcf44493d8cd9d7f405b986d73944dbba7bd31R1-R10) [[2]](diffhunk://#diff-aeacb823c3852820f43fa408e0620125ee7d9074167659a92b05f4831517996eR1-R18) [[3]](diffhunk://#diff-49fed124d860b3ea0451ff9f6513f8c1c64d4ccfacb09bbaab2cbe6fd5cd9807R41-R44)
* Added database migrations and schema updates for new tables (`admin_fees`, `owner_statements`) and the `fee_rate_pct` column on `contracts`. [[1]](diffhunk://#diff-bde844ae212d689450bcc335b6cec44182d056884a2c456a4611fcb6876370efR1-R6) [[2]](diffhunk://#diff-0f1c112b18ec9b60f72c4d6c423b9dff0a1f1eab751f46f18724f40208272e2bR1-R16) [[3]](diffhunk://#diff-b13e2ad7e61539ba67f4f1b3a450d34744241820d95d4c2b6c8c5f45b6c683daR1-R16) [[4]](diffhunk://#diff-5fed5c95a66de3eb2f404c0ce2f088c1e1890c5cc5ac01cbb1ce2a38b2dd3518L13-R29) [[5]](diffhunk://#diff-5fed5c95a66de3eb2f404c0ce2f088c1e1890c5cc5ac01cbb1ce2a38b2dd3518R50-R51) [[6]](diffhunk://#diff-5fed5c95a66de3eb2f404c0ce2f088c1e1890c5cc5ac01cbb1ce2a38b2dd3518R79-R90) [[7]](diffhunk://#diff-5fed5c95a66de3eb2f404c0ce2f088c1e1890c5cc5ac01cbb1ce2a38b2dd3518R172-R179)
* Implemented serializers and factory definitions for new models, and added request/service specs to ensure correct behavior. [[1]](diffhunk://#diff-8d93db724ecf2dd8352234f4c1fc5b4c39c87221dce18141a9ec3a0098890521R1-R3) [[2]](diffhunk://#diff-86871d66a3af043a20fe660690b48afd27d7adf032652e8eb73b86be0a2ba4c8R1-R3) [[3]](diffhunk://#diff-059284e768dd420da1fb3e7d7fd32cb68b16b8e14da5c845b63d6673db4c42aaR1-R10) [[4]](diffhunk://#diff-eea72e3e971609dabaa96dac97012ac26398262790684a77dd2a26410a5374c2R1-R10) [[5]](diffhunk://#diff-65fa0ac8bdc47e6b993726409ca2c301d05e243e191ee61db5e38330f2eadd72R1-R23) [[6]](diffhunk://#diff-babb5a59b488a631325a9ddfcf6e7544776d2913ce6d8d87001bb7f8fc5795c4R1-R17) [[7]](diffhunk://#diff-23d3ebb54cfb872091259a6c303a6382086431532ed9b9c6657715aa28a2318aR1-R19)
